### PR TITLE
Fix #6: honor warpd emitted errors always

### DIFF
--- a/client/command/connect.go
+++ b/client/command/connect.go
@@ -223,6 +223,7 @@ func (c *Connect) Execute(
 
 	// Listen for state updates.
 	go func() {
+	STATELOOP:
 		for {
 			if st, err := c.ss.DecodeState(ctx); err != nil {
 				break
@@ -236,7 +237,7 @@ func (c *Connect) Execute(
 
 			select {
 			case <-ctx.Done():
-				break
+				break STATELOOP
 			default:
 			}
 		}

--- a/lib/plex/plex.go
+++ b/lib/plex/plex.go
@@ -12,6 +12,7 @@ func Run(
 	src io.Reader,
 ) {
 	buf := make([]byte, 1024)
+PLEXLOOP:
 	for {
 		nr, err := src.Read(buf)
 		if nr > 0 {
@@ -24,7 +25,7 @@ func Run(
 		}
 		select {
 		case <-ctx.Done():
-			break
+			break PLEXLOOP
 		default:
 		}
 	}


### PR DESCRIPTION
- Avoid dead lock on deferred pty close 
- Avoid infinite reconnect loop

Warp correctly exits whenever warpd issues an error.