### PR TITLE
Fix comment typo in protocol.go

### DIFF
--- a/protocol.go
+++ b/protocol.go
@@ -63,7 +63,7 @@ type Error struct {
 	Message string
 }
 
-// Size reprensents a window size.
+// Size represents a window size.
 type Size struct {
 	Rows int
 	Cols int


### PR DESCRIPTION
Just noticed this while skimming the source and figured I'd submit a quick patch.